### PR TITLE
x86/x64 build error for UCL fixed

### DIFF
--- a/ucl/asm/asminit.def
+++ b/ucl/asm/asminit.def
@@ -25,10 +25,19 @@
 ;  http://www.oberhumer.com/opensource/ucl/
 ;
 
-; this is unsupported in x64 configuration and not really useful for x86
-; .386p
-; .model flat
+IFDEF RAX
+
+; x64 variant
+
+ELSE
+
+; x86 variant
+
+.386p
+.model flat
 .code
+
+ENDIF
 
 ifdef __MASM__
 option casemap:none

--- a/ucl/asm/asminit.def
+++ b/ucl/asm/asminit.def
@@ -35,9 +35,10 @@ ELSE
 
 .386p
 .model flat
-.code
 
 ENDIF
+
+.code
 
 ifdef __MASM__
 option casemap:none


### PR DESCRIPTION
x64 support killed x86 support, missed this. Now everything tested and working fine on both platforms.